### PR TITLE
Update session cookie in RFC 134

### DIFF
--- a/rfc-134-govuk-wide-session-cookie-and-login.md
+++ b/rfc-134-govuk-wide-session-cookie-and-login.md
@@ -109,7 +109,7 @@ strings.
 This cookie is a secure, [domain-locked][], session cookie:
 
 ```
-Set-Cookie: __Host-govuk_account_session=<value>; secure; httponly; samesite=strict; path=/
+Set-Cookie: __Host-govuk_account_session=<value>; secure; httponly; samesite=lax; path=/
 ```
 
 It can be expired, logging a user out, by re-setting it with
@@ -200,10 +200,10 @@ response depended on the session:
 
 ```vcl
 if (resp.http.GOVUK-Account-End-Session) {
-  add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=strict; path=/; max-age=0"
+  add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0"
   unset resp.http.GOVUK-Account-End-Session;
 } else if (resp.http.GOVUK-Account-Session) {
-  add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=strict; path=/"
+  add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=lax; path=/"
 }
 
 if (resp.http.Vary ~ "GOVUK-Account-Session") {


### PR DESCRIPTION
We had to change this to use samesite=lax because of issues with
cross-domain links.

The change has already been implemented, so this commit just updates
the RFC to reflect the current state.