### PR TITLE
Add RFC metadata as YAML frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,31 @@ For RFCs where the outcome is an agreed Action Plan, you may want to update the 
 
 Some RFCs in this repository were migrated from Confluence. They’ve been automatically converted to Markdown, so some formatting might be incorrect. Please fix any issues as you find them in new PRs.
 
+## RFC metadata as YAML frontmatter
+
+Some RFCs have YAML frontmatter which allows us to track their status / implementation etc.
+
+<details>
+<summary>Script to list all RFC metadata</summary>
+
+```ruby
+#!/usr/bin/env ruby
+
+require "csv"
+require "yaml"
+
+frontmatter_columns = %w[status implementation status_last_reviewed status_notes]
+CSV do |csv|
+  csv << ["filename", *frontmatter_columns]
+  Dir.glob("rfc-*.md") do |filename|
+    first_line = File.readlines(filename).first
+    frontmatter = {}
+    frontmatter = YAML.load_file(filename, permitted_classes: [Date]) if first_line =~ /^---$/
+    csv << [filename, *frontmatter.values_at(*frontmatter_columns)]
+  end
+end
+```
+
+</details>
+
 [govuk-tech-members]: https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/govuk-tech-members

--- a/rfc-088-external-content.md
+++ b/rfc-088-external-content.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # External content
 
 ## Summary

--- a/rfc-091-sharing-assets.md
+++ b/rfc-091-sharing-assets.md
@@ -1,3 +1,10 @@
+---
+status: unclear
+implementation: abandoned
+status_last_reviewed: 2024-03-04
+status_notes: We're currently thinking about consolidating apps as a better alternative to changing the way we share assets.
+---
+
 # Sharing assets
 
 ## Summary

--- a/rfc-093-retire-govuk-cdn-logs-monitor.md
+++ b/rfc-093-retire-govuk-cdn-logs-monitor.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Retire GOV.UK CDN Logs Monitor
 
 ## Summary

--- a/rfc-095-long-term-future-apps.md
+++ b/rfc-095-long-term-future-apps.md
@@ -1,3 +1,11 @@
+---
+status: superseded
+implementation: superseded
+status_last_reviewed: 2024-03-04
+status_notes: RFC 161 updates this for publishing related apps, but we haven't
+  got an up to date view of the plan for some frontend / data apps.
+---
+
 # RFC 95: Long term future of applications
 
 **Update August 2023:** As this is now multiple years old, it can no longer be considered to represent current direction of travel. Information in this related to GOV.UK Publishing applications has been superseded by [RFC-161](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-161-technical-direction-in-publishing-2023.md).

--- a/rfc-097-verify-specific-start-pages.md
+++ b/rfc-097-verify-specific-start-pages.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Providing alternative GOV.UK service start pages for the GOV.UK Verify single IDP journey
 
 ## Summary

--- a/rfc-098-csp.md
+++ b/rfc-098-csp.md
@@ -1,3 +1,10 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+status_notes: RFC may not be accurate in the implementation details.
+---
+
 # RFC 98: Implement Content Security Policy
 
 ## Summary

--- a/rfc-100-linting.md
+++ b/rfc-100-linting.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # RFC 💯: Update linting system
 
 ## Summary

--- a/rfc-103-merge-dependabot-pull-requests-with-a-single-review.md
+++ b/rfc-103-merge-dependabot-pull-requests-with-a-single-review.md
@@ -1,3 +1,11 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
+# Merge dependabot pull requests with a single review
+
 ## Problem
 
 I think there are two somewhat related problems that I'd like to see

--- a/rfc-106-docker-for-local-development.md
+++ b/rfc-106-docker-for-local-development.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # RFC 106: Use Docker for local development
 
 ## Summary

--- a/rfc-108-including-gem-component-assets.md
+++ b/rfc-108-including-gem-component-assets.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Include specific component assets in applications
 
 ## Summary

--- a/rfc-113-expanding-draft-access-for-unauthenticated-users.md
+++ b/rfc-113-expanding-draft-access-for-unauthenticated-users.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Expanding draft access for unauthenticated users to allow multi-page fact checks
 
 ## Summary

--- a/rfc-115-enabling-http2-on-govuk.md
+++ b/rfc-115-enabling-http2-on-govuk.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Enabling HTTP/2 on GOV.UK
 
 ## Deadline for comments

--- a/rfc-116-store-attachment-data-in-content-items.md
+++ b/rfc-116-store-attachment-data-in-content-items.md
@@ -1,3 +1,13 @@
+---
+status: accepted
+implementation: in_progress
+status_last_reviewed: 2024-03-04
+status_notes: This is in a bit of a confusing, half-way house state. Content
+  items do have attachments hashes, but the HTML in the content item is still
+  there and still used in the frontend. We also still have the concept of
+  inline attachments, which are a further inconsistency.
+---
+
 # Store attachment data in content items
 
 ## Summary

--- a/rfc-117-container-runtime.md
+++ b/rfc-117-container-runtime.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # RFC 117: Use a container runtime
 
 ## Summary

--- a/rfc-122-csv-preview.md
+++ b/rfc-122-csv-preview.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # CSV Preview
 
 [govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas

--- a/rfc-123-github-actions-ci.md
+++ b/rfc-123-github-actions-ci.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # RFC-123: Use GitHub Actions for CI
 
 ## Summary

--- a/rfc-126-custom-configuration-for-dependabot.md
+++ b/rfc-126-custom-configuration-for-dependabot.md
@@ -1,3 +1,9 @@
+---
+status: superseded
+implementation: superseded
+status_last_reviewed: 2024-03-04
+---
+
 # Custom configuration for Dependabot
 
 UPDATE AUGUST 2022: this is now superseded. We've agreed to remove 'allow lists' to preserve security updates. See [RFC-153](https://github.com/alphagov/govuk-rfcs/pull/153).

--- a/rfc-128-continuous-deployment.md
+++ b/rfc-128-continuous-deployment.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Continuous Deployment
 
 ## Summary

--- a/rfc-134-govuk-wide-session-cookie-and-login.md
+++ b/rfc-134-govuk-wide-session-cookie-and-login.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # A GOV.UK-wide session cookie & login
 
 ## Summary

--- a/rfc-135-updating-routes-in-router.md
+++ b/rfc-135-updating-routes-in-router.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Updating routes in Router
 
 ## Summary

--- a/rfc-136-remove-our-backup-cdn-in-gcp.md
+++ b/rfc-136-remove-our-backup-cdn-in-gcp.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Remove the backup CDN in Google Cloud Platform (GCP)
 
 ## Summary

--- a/rfc-138-enable-brotli-compression.md
+++ b/rfc-138-enable-brotli-compression.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Enable Brotli compression on GOV.UK
 
 ## Summary

--- a/rfc-139-enable-http3.md
+++ b/rfc-139-enable-http3.md
@@ -1,3 +1,10 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+status_notes: RFC could do with a note on how this is performing now that it's been rolled out.
+---
+
 # Enabling HTTP/3 on GOV.UK
 
 ## Summary

--- a/rfc-141-application-healthchecks.md
+++ b/rfc-141-application-healthchecks.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Application Healthchecks
 
 ## Summary

--- a/rfc-142-add-interest-cohort-permssion-policy-header.md
+++ b/rfc-142-add-interest-cohort-permssion-policy-header.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Add Interest cohort permission policy header
 
 ## Summary

--- a/rfc-143-split-database-instances.md
+++ b/rfc-143-split-database-instances.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # One database per RDS instance
 
 ## Summary

--- a/rfc-144-consistent-cache-expiry.md
+++ b/rfc-144-consistent-cache-expiry.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # 144 More reliable emergency banner deployment
 
 Author: Bill Franklin\

--- a/rfc-145-unarchive-govuk_admin_template.md
+++ b/rfc-145-unarchive-govuk_admin_template.md
@@ -1,8 +1,10 @@
 ---
-Author: Ryan Brooks
-Date: January 2022
-Deadline for decision: 14th January 2022
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+status_notes: "We're getting close to being able to archive this again, with the publishing apps removing their dependency on Bootstrap"
 ---
+
 # Unarchive govuk_admin_template Bootstrap project
 ## Summary
 

--- a/rfc-146-production-deploy-access.md
+++ b/rfc-146-production-deploy-access.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # RFC 146 - Implement "Production Deploy Access"
 
 ## Summary

--- a/rfc-147-enable-speedcurve-http-protocol-capture.md
+++ b/rfc-147-enable-speedcurve-http-protocol-capture.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Allow SpeedCurve to capture user HTTP Protocol Data
 
 ## Summary

--- a/rfc-149-switch-to-per-page-asset-loading.md
+++ b/rfc-149-switch-to-per-page-asset-loading.md
@@ -1,7 +1,9 @@
 ---
-Author: Ian James
-Date: 2 August 2022
-Deadline for decision: 16 August 2022
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+status_notes: >
+  This is done for CSS, but not JS as we're still working out how ES modules will change the way we load JS.
 ---
 
 # Serve component CSS and JavaScript as individual files

--- a/rfc-153-remove-allowlists-from-dependabot-configs.md
+++ b/rfc-153-remove-allowlists-from-dependabot-configs.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Remove allowlists from Dependabot configs
 
 ## Summary

--- a/rfc-154-integrating-an-ots-cms-with-govuk-for-custom-pages.md
+++ b/rfc-154-integrating-an-ots-cms-with-govuk-for-custom-pages.md
@@ -1,3 +1,12 @@
+---
+status: accepted
+implementation: abandoned
+status_last_reviewed: 2024-03-04
+status_notes: >
+  We demonstrated that this was technically possible, but the business hasn't
+  agreed that integrating an off-the-shelf CMS is still a priority at this point.
+---
+
 # Integrating an off-the-shelf CMS with GOV.UK infrastructure to power custom pages
 
 ## Summary

--- a/rfc-156-auto-merge-internal-prs.md
+++ b/rfc-156-auto-merge-internal-prs.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Allow auto-merging of 'internal' Dependabot PRs
 
 ## Summary

--- a/rfc-158-port-content-store-to-postgresql.md
+++ b/rfc-158-port-content-store-to-postgresql.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Port Content Store to PostgreSQL on RDS
 
 ## Summary

--- a/rfc-159-switch-off-whitehall-apis.md
+++ b/rfc-159-switch-off-whitehall-apis.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Switch off Whitehall's public APIs
 
 ## Summary

--- a/rfc-161-technical-direction-in-publishing-2023.md
+++ b/rfc-161-technical-direction-in-publishing-2023.md
@@ -1,3 +1,10 @@
+---
+status: accepted
+implementation: in_progress
+status_last_reviewed: 2024-03-04
+status_notes: 'Should be superseded by Technical Direction in Publishing 2024'
+---
+
 # Technical Direction in Publishing 2023
 
 ## Summary

--- a/rfc-163-cdn-rationalisation.md
+++ b/rfc-163-cdn-rationalisation.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Simplify our CDN config, and standardise on Terraform for deployment
 
 ## Summary

--- a/rfc-164-retire-email-alert-monitoring-as-a-separate-app.md
+++ b/rfc-164-retire-email-alert-monitoring-as-a-separate-app.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: done
+status_last_reviewed: 2024-03-04
+---
+
 # Retire email-alert-monitoring as a separate app
 
 ## Summary

--- a/rfc-165-add-api-endpoints-to-transition.md
+++ b/rfc-165-add-api-endpoints-to-transition.md
@@ -1,3 +1,12 @@
+---
+status: to_be_deleted
+implementation: not_planned
+status_last_reviewed: 2024-03-04
+status_notes: >
+  People aren't clear whether the value of doing this outweighs the cost of implementing it.
+  Given that disagreement, it seems unlikely that any team is going to pick this up.
+---
+
 # Add API endpoints to Transition for consumption by Bouncer
 
 ## Summary

--- a/rfc-167-auto-patch-dependencies.md
+++ b/rfc-167-auto-patch-dependencies.md
@@ -1,3 +1,9 @@
+---
+status: accepted
+implementation: in_progress
+status_last_reviewed: 2024-03-04
+---
+
 # Allow automatic patching of all dependencies
 
 ## Summary


### PR DESCRIPTION
We reviewed the latest 42 RFCs with senior tech to check on their statuses (i.e. accepted / superseded etc.) and implementation status (i.e. done / in progress etc.).

This adds metadata to each RFC as YAML frontmatter.

Also add a script to the README to show how this can be used in a programmatic way. The results of running this script can be seen in this spreadsheet:

https://docs.google.com/spreadsheets/d/1bYF7r4IC7owbE7NrbFMZYJiuqsPZeQka1fzYD4apx9U/edit#gid=166323961