### PR TITLE
Update process documentation to reflect used conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,22 @@ GOV.UK staff use this repository as a forum to discuss and make technical decisi
 
 1. Create a new branch on this repo and copy `rfc-000-template.md` to `rfc-000-my-proposal.md` and edit.
 2. Include any images etc in a separate directory named `rfc-000` and link to them.
-3. Make a Pull Request (PR) for your branch.
-4. Rename your file and directory with the number of the PR and push as a new commits.
-5. Post a link to your PR in #govuk-developers on Slack and to the [govuk-tech-members][govuk-tech-members] Google Group. @mention teams in the PR description if you want particular attention from them.
+3. Make a Pull Request (PR) for your branch and open as a draft.
+4. Rename your file and directory with the number of the PR and push changes.
+5. When your RFC is ready to be commented on, mark you PR as "Ready for review" and set a deadline for comments (2 weeks is a common choice) and record that in the PR description.
+5. Post a link to your PR in #govuk-developers on Slack and to the [govuk-tech-members][govuk-tech-members] Google Group.
 6. GOV.UK members discuss your proposal using both inline comments against your RFC document and the general PR comments section. Non-technical staff will need to create a free Github account in order to comment.
 7. As changes are requested and agreed in comments, make the changes in your RFC and push them as new commits.
-8. Stay active in the discussion and encourage and remind other relevant people to participate. If you’re unsure who should be involved in a discussion, ask your Tech Lead or a Lead Developer. If you start an RFC it’s up to you to push it through the process and engage people.
-9. Once consensus is reached and approvals given using the Github review system, the PR can be merged.
-10. When an RFC is accepted, ensure the GOV.UK Technical community is made aware of it via Slack and the Google Group.
-11. An RFC can be rejected. This can happen if a consensus isn’t reached, or people agree rejecting it is the right thing to do. In this case the PR should be closed with a suitable comment.
+8. Stay active in the discussion and encourage other relevant people to participate. If you’re unsure who should be involved in a discussion, ask your Tech Lead or a Lead Developer. If you start an RFC it’s up to you to push it through the process and engage people.
+9. Once the deadline is reached you are able to merge if the PR has been approved by a member of GOV.UK Senior Tech (if they haven't or you're not sure, you can contact them on Slack with @govuk-senior-tech-people) - this action is the accepting of an RFC.
+
+### If consensus isn't reached
+
+Should consensus not be reached by the deadline, an RFC can either have the deadline extended or the RFC can be closed as something not approiate for accepting now. For a deadline extension, you should make an effort to inform #govuk-developers about this status and request extra input. If the RFC is being closed, leave a comment explaining the status and close the PR.
+
+### If the proposal is no longer needed
+
+If the proposal is no longer applicable the RFC PR can be closed. Please include a comment explaining why to help anyone considering the problem in future.
 
 ## Managing Standards
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GOV.UK Request For Comments
 
-GOV.UK staff use this repository as a forum to discuss and make technical decisions. The outcomes of these discussions can be either an Action Plan, or a new Standard that GOV.UK should follow. This repository is open as a reference for other teams within GDS and wider government.
+GOV.UK staff use this repository as a forum to discuss and make technical decisions. The outcomes of these discussions can be either an action plan, or a new standard that GOV.UK should follow. This repository is open as a reference for other teams within GDS and wider government.
 
 ## Process
 

--- a/README.md
+++ b/README.md
@@ -23,16 +23,14 @@ Should consensus not be reached by the deadline, an RFC can either have the dead
 
 If the proposal is no longer applicable the RFC PR can be closed. Please include a comment explaining why to help anyone considering the problem in future.
 
-## Managing Standards
+## Editing past RFCs
 
-Standards RFCs shouldn’t be substantially altered after they are accepted, although it’s fine to correct typos and other mistakes via a new PR. In order to change a Standard, the original RFC must be superseded by a new one. The process for this is:
+RFCs should not be substantially altered after they are accepted as they intended to be kept as a point-in-time record of a decision. There are however a few reasons why you may change one that has been accepted:
 
-1. Create a new RFC PR as above, noting in the summary which RFC it is superseding.
-2. In the same branch, mark the old RFC as superseded and link to the new RFC and move (using `git mv`) it into the archived directory.
-3. When the new RFC is accepted and the PR is merged, the old RFC will no longer be active.
-
-## Managing Action Plans
-For RFCs where the outcome is an agreed Action Plan, you may want to update the RFC with meaningful status updates in new PRs. Once the plan is either complete or no longer relevant, it should be moved to the archived directory in a new PR.
+- to fix typos and other minor mistakes
+- to record a status change of the RFC in the YAML frontmatter (remember to update the status_last_reviewed date)
+- to mark an RFC as being superseded with a link to the RFC that supersedes it
+- any relevant post implementation, or post abandonment, supplementary details that would be useful for someone interested in the area.
 
 ## Historical RFCs
 


### PR DESCRIPTION
This updates the process to reflect that RFCs should have a deadline and that senior tech members are the final voice of whether an RFC is accepted. I'm surprised this wasn't previously documented.

It also replaces notes about how to manage Action Plans, Standards and archiving since those concepts have never become established.