### PR TITLE
RFC-188: Make Whitehall the Authority of its own Taxons [WHIT-3066]

### DIFF
--- a/rfc-188-make-whitehall-the-authority-on-its-taxons.md
+++ b/rfc-188-make-whitehall-the-authority-on-its-taxons.md
@@ -21,79 +21,82 @@ Whitehall will:
 
 - Persist selected taxons locally, scoped to Editions.
 - Render taxon tagging from local persistence (removing eventual-consistency delays).
-- Push a complete, authoritative set of taxon links to Publishing API:
-  - as edition_links on draft save
-  - as edition_links and link set updates on publish/republish
+- Push a complete, authoritative set of taxon links to Publishing API, as edition_links
 
 The list of available taxons (the taxonomy catalogue) will continue to be fetched and cached from the publishing stack.
 
-## Problem
+It is also worth noting that this proposal makes Whitehall the canonical source of Topic/World Taxonomy associations for Whitehall content _only_. The RFC does not propose changing the canonical source of these associations for any non-Whitehall content, which remains the responsibility of Content Tagger.
 
-### User problem
+### Benefits
 
-After tagging an Edition with taxons in Whitehall, subsequent refreshes often do not reflect the change immediately, especially in the local dev environment.
-
-This is caused by Whitehall reading taxon tagging from Publishing API at runtime while the update is processed asynchronously or cached (TBC: which?).
-
-This results in:
-
-- confusing UX ("did it save?")
-- reduced trust in the system
-- runtime coupling between Whitehall and Publishing API for editorial workflows
-- friction and delays in local development
-
-### Technical problem
-
-Taxon tagging for Whitehall-managed content is currently treated as externally-owned state:
-
-- Whitehall must query Publishing API at runtime to display tagging.
-- Draft and live semantics are harder to reason about.
-- Topic and world taxonomies must both be considered when reading/writing.
-- Data flow differs from other Whitehall associations.
+- Eradicates the root cause of a race condition.
+- Simplifies Whitehall and makes it more internally consistent.
+- Enables different topic/world taxonomies on draft vs live content.
+- Removes runtime coupling between Whitehall and Publishing API for tagging.
 
 ## Context
 
-- Taxonomies (topic + world) are maintained outside Whitehall (in Content Tagger).
-- Taxons are stored in Publishing API as content items.
-- Publishing API stores links by `content_id`.
-TODO: double-check the following definitions:
-- Link sets are document-scoped (not edition-scoped).
-- Edition links are draft-scoped and allow draft/live divergence.
+- Taxonomies (both topic + world) are:
+  - Maintained outside Whitehall (in Content Tagger).
+  - Stored in Publishing API as content items (see examples below).
+  - Presented as a combined `taxons` link on content items ([example](https://www.gov.uk/api/content/government/publications/latvia-list-of-medical-facilities)).
+- Publishing API [link lifecycles](https://docs.publishing.service.gov.uk/repos/publishing-api/link-expansion.html#link-lifecycles):
+  - Link sets are document-scoped (not edition-scoped).
+  - Edition links are draft-scoped and allow draft/live divergence.
+- Whitehall prefers draftable associations (e.g. organisations via edition_links) so that changes made on a draft edition do not affect the live edition until publish.
 
-Whitehall prefers draftable associations (e.g. organisations via edition_links) so that changes made on a draft edition do not affect the live edition until publish.
+Taxons are not special in Publishing API — they are stored as a standard `"taxons"` link type. There are no hardcoded rules requiring Content Tagger to be the canonical writer.
 
-This RFC aligns taxon tagging with that model.
+```rb
+# Publishing API
 
-## Investigation: Publishing API behaviour
+topic_taxon = Document.find_by(content_id: "71f685fe-0dc3-469d-92c2-1000ad86d7d9").editions.last
+=> 
+#<Edition:0x0000ffff68066130
+ id: 3359281,
+ title: "River maintenance, flooding and coastal erosion",
+ publishing_app: "content-tagger",
+ rendering_app: "collections",
+ update_type: "major",
+ document_type: "taxon",
+ schema_name: "taxon",
+ first_published_at: "2018-03-08 16:32:37.000000000 +0000",
+ last_edited_at: "2018-09-16 10:36:13.350772000 +0000",
+ state: "published",
+ content_store: "live",
+ routes: [{"path" => "/environment/river-maintenance-flooding-coastal-erosion", "type" => "exact"}]>
 
-### Key findings
+world_taxon = Document.find_by(content_id: "7283f126-c578-4df7-949e-44662d4c086b").editions.last
+=> 
+#<Edition:0x0000ffff5e47a780
+ id: 4682028,
+ title: "Living in Latvia",
+ publishing_app: "content-tagger",
+ rendering_app: "collections",
+ update_type: "major",
+ document_type: "taxon",
+ schema_name: "taxon",
+ first_published_at: "2017-06-29 14:02:28.826713000 +0000",
+ last_edited_at: "2020-03-03 16:56:27.160273000 +0000",
+ state: "published",
+ content_store: "live",
+ routes: [{"path" => "/world/living-in-latvia", "type" => "exact"}]>
+```
 
-TODO: double-check and verify the below.
+## Problem
 
-1. Taxons are not special in Publishing API.
-   - They are just another link type: `"taxons"`.
-   - There are no hardcoded business rules restricting which publishing app may set taxons.
+Taxon tagging for Whitehall-managed content is currently treated as externally-owned state. Whitehall queries Publishing API at runtime to display tagging.
 
-2. Publishing API does not distinguish topic vs world taxonomy at storage level.
-   - Both are stored under `"taxons"`.
+Consequences:
 
-3. Link sets are tied to `content_id` and are not edition-scoped.
-   - Writing to link sets affects the document-level associations.
-
-4. Edition links are draft-scoped and allow draft/live divergence.
-
-5. Publishing API does not automatically merge partial link updates.
-   - PATCHing links requires sending the full desired set.
-   - Omitting links risks overwriting them.
-
-6. Content Tagger writes taxons by mutating Publishing API link sets.
-   - There is no enforcement that only Content Tagger may do so.
-
-Conclusion:
-
-There are no hidden business rules in Publishing API that prevent Whitehall from becoming authoritative for taxon tagging.
-
-The main risk is partial overwriting of link sets, which can be mitigated by always sending the full combined set.
+- Inconsistent with how Whitehall models other associations.
+- Makes consolidation of a config-driven association architecture more difficult.
+- Introduces runtime coupling to Publishing API.
+- Code is more complex to reason about.
+- Race conditions have been observed whereby saving new taxon selections takes time to “stick”, showing stale data on refresh.
+  - This hinders local development (topic-less documents are invalid and cannot be force-published).
+  - The issue has also been observed in integration.
+- Taxon tagging is currently implemented as link set links, meaning draft changes immediately affect live associations.
 
 ## Proposal
 
@@ -101,16 +104,16 @@ The main risk is partial overwriting of link sets, which can be mitigated by alw
 
 Whitehall will store selected taxons per Edition.
 
-This enables draft editions to differ from live editions.
-
-Proposed model will be something like:
+Proposed model:
 
 - `edition_taxon_links`
   - `edition_id`
   - `taxon_content_id`
   - `taxonomy_kind` (enum: `topic`, `world`)
 
-When a new edition is created, it will inherit taxons from the previous edition.
+When a new edition is created, it will duplicate taxon links from the previous edition.
+
+This enables draft editions to differ from live editions.
 
 ### 2. Render from local persistence
 
@@ -118,86 +121,46 @@ Whitehall UI will render taxon tagging from `edition_taxon_links`.
 
 Whitehall will no longer call Publishing API at runtime to determine which taxons an Edition is tagged to.
 
-This removes:
-
-- eventual-consistency issues
-- runtime dependency on Publishing API
-- cross-app state ambiguity
-
-### 3. Draft vs Live semantics
-
-Whitehall prefers draftable associations.
-
-Therefore:
-
-#### On save draft
-
-- Taxons are written as edition_links only.
-- Link sets are NOT updated.
-- Live associations remain unchanged.
-
-TODO: is there a case for dropping link set links altogether?
-
-#### On publish / republish
-
-- Taxons are written as edition_links.
-- The document’s link set is updated via `PATCH /v2/links/:content_id`.
-- The full combined set of topic + world taxons is sent.
-
-This ensures:
-
-- Draft changes do not affect live content prematurely.
-- Link sets remain authoritative for live content.
-- Downstream consumers receive correct associations.
-
-### 4. Always send full combined taxon set
-
-When updating link sets:
-
-- Whitehall must always send the complete combined set of topic + world taxons.
-- Partial updates are not permitted.
-
-This avoids accidental overwriting of one taxonomy with another.
-
-### 5. Continue fetching taxonomy catalogue
-
 Whitehall will continue to fetch and cache the list of available taxons from the publishing stack.
 
-This proposal changes tagging ownership, not taxonomy ownership.
+This proposal changes tagging ownership, not taxonomy ownership. The question of taxonomy ownership and governance is being investigated separately by the `#govuk-publishing-tagging-workflow` team.
 
-## Migration Plan
+### 3. Update Publishing API integration
 
-### 1. Backfill
+Taxon links will no longer be managed via `patch_links`.
+
+Instead, taxons will be sent via `put_content` as edition links, like Whitehall's other associations.
+
+Whitehall must always send the complete combined set of topic + world taxons. Partial updates are not permitted.
+
+At this stage we have fully editionable taxonomies — no further use of link sets for taxons.
+
+## Implementation Plan
+
+### Phase 1 – Introduce local persistence
+
+- Create `edition_taxon_links`.
+- Continue writing to Publishing API as currently implemented. In addition, write the taxon selections locally.
+- Duplicate taxon links when new editions are created.
+- Continue reading taxon selections from Publishing API. Do not yet switch rendering.
+
+### Phase 2 – Backfill existing data
 
 For each Whitehall document:
 
 - Fetch existing taxon link sets from Publishing API.
-- Populate `edition_taxon_links` for the latest edition.
+- Populate/overwrite `edition_taxon_links` for both the live and draft editions (if applicable).
+- Ensure both topic and world taxons are captured.
 
-Both topic and world taxons must be included.
+### Phase 3 – Switch read path
 
-### 2. Dual-read period (temporary)
+- Render taxon tagging from `edition_taxon_links`.
+- Remove runtime reads from Publishing API.
 
-For a limited period:
+### Phase 4 – Remove link set updates
 
-- Compare local taxon set vs Publishing API link set.
-- Log diffs.
-- Identify edge cases.
-
-### 3. Switch UI reads
-
-Switch Whitehall to render from local persistence only.
-
-### 4. Switch publish writes
-
-Update publish/republish flow to:
-
-- Write edition_links
-- PATCH link set with full combined taxon set
-
-### 5. Remove runtime dependency
-
-Remove all runtime reads of taxon tagging from Publishing API.
+- Remove `patch_links` usage for taxons.
+- At this stage, taxonomies are updated solely on edition_links via `put_content`.
 
 ## Governance Considerations
 
@@ -205,6 +168,7 @@ After this change:
 
 - Whitehall is authoritative for taxon tagging on Whitehall-managed content.
 - If Content Tagger mutates taxons for Whitehall content, those changes will be overwritten on next republish.
+- NB: Content Tagger as an application has [low and poorly defined usage](https://gds.slack.com/archives/C0A5B765LUV/p1771244116138289?thread_ts=1770918971.536859&cid=C0A5B765LUV) and has not received meaningful updates in several years.
 
 Optional mitigations:
 
@@ -216,67 +180,31 @@ Optional mitigations:
 ### Risk: Partial link overwrites
 
 Mitigation:
-- Always send full combined taxon set on link set update.
+- Always send full combined taxon set via `put_content`.
 
 ### Risk: Draft save mutates live links
 
+(Currently true under link set model.)
+
 Mitigation:
-- Do not update link sets on save draft.
-- Only update link sets on publish/republish.
+- Remove `patch_links`.
+- Use edition_links only, ensuring draft changes do not affect live until publish.
 
 ### Risk: Backfill misses world taxonomy
 
 Mitigation:
 - Explicitly backfill both topic and world taxons.
-- Validate counts before switching.
+- Validate counts before and after switching.
 
-### Risk: Unexpected downstream dependency on Content Tagger
-
-Investigation shows:
-- Downstream systems rely on link sets, not on Content Tagger as a writer.
-- There are no hidden business rules coupling taxons to Content Tagger.
+### Risk: A taxon is deleted from Content Tagger
 
 Mitigation:
-- Dual-read phase and monitoring.
-
-## Alternatives Considered
-
-### Continue pulling from Publishing API
-
-Pros:
-- Single source of truth
-Cons:
-- Runtime coupling
-- UX inconsistency
-- Harder to reason about draft/live
-- Requires careful topic/world handling on every read
-
-### Optimistic UI but keep Publishing API authoritative
-
-Pros:
-- Less invasive
-Cons:
-- Does not align with “Whitehall is authoritative”
-- Still runtime-coupled
-
-### Make Content Tagger canonical for Whitehall content
-
-Rejected:
-- Whitehall is primary editorial interface.
-- Cross-app editing causes ambiguity.
-
-## Impact
-
-- Immediate UX improvement for tagging.
-- Reduced runtime coupling.
-- Consistent association model across Whitehall.
-- Clear ownership model for taxon tagging.
-- Explicit handling of topic + world taxonomy together.
-- Paves the way for easily configuring whether topic/world taxonomies should be required on a per-content type basis (following Whitehall's new config-driven approach).
+- Update the [Taxonomy::RedisCacheAdapter](https://github.com/alphagov/whitehall/blob/07d624404ba3dd3fd06d5bbc241354c4a57ecb46/lib/taxonomy/redis_cache_adapter.rb#L1-L2) such that, on update, it cross-references all taxons by their content ID in the `edition_taxon_links` table and drops any rows where the taxon no longer exists.
+- Note that this could lead to previously valid editions now being 'invalid' as a result of having their only topic taxonomy removed. This is considered a better situation than continuing to assume the edition is valid (which has been the cause of bugs - see [whitehall#10440](https://github.com/alphagov/whitehall/pull/10440)).
 
 ## Success Criteria
 
 - Tagging changes appear immediately after save.
 - Draft tagging differs from live until publish.
-- Publishing API link sets reflect correct combined taxon set after publish.
+- Publishing API reflects correct combined taxon set after publish.
 - Whitehall no longer depends on Publishing API for runtime taxon lookup.

--- a/rfc-188-make-whitehall-the-authority-on-its-taxons.md
+++ b/rfc-188-make-whitehall-the-authority-on-its-taxons.md
@@ -1,0 +1,282 @@
+---
+status: proposed
+implementation: not_started
+status_last_reviewed: 
+---
+
+# Make Whitehall authoritative for taxon tagging (topic + world) on Whitehall-managed content
+
+## Summary
+
+Whitehall currently pulls taxon tagging ("taxons") from Publishing API at runtime to determine which topics and worlds an Edition is tagged to.
+
+This differs from other Whitehall associations (for example organisations), where Whitehall persists associations locally and pushes them to Publishing API at publish time.
+
+This RFC proposes that, for Whitehall-managed content, Whitehall becomes the authoritative editor of taxon tagging for:
+
+- the GOV.UK topic taxonomy, and
+- the GOV.UK world taxonomy (legacy taxonomy).
+
+Whitehall will:
+
+- Persist selected taxons locally, scoped to Editions.
+- Render taxon tagging from local persistence (removing eventual-consistency delays).
+- Push a complete, authoritative set of taxon links to Publishing API:
+  - as edition_links on draft save
+  - as edition_links and link set updates on publish/republish
+
+The list of available taxons (the taxonomy catalogue) will continue to be fetched and cached from the publishing stack.
+
+## Problem
+
+### User problem
+
+After tagging an Edition with taxons in Whitehall, subsequent refreshes often do not reflect the change immediately, especially in the local dev environment.
+
+This is caused by Whitehall reading taxon tagging from Publishing API at runtime while the update is processed asynchronously or cached (TBC: which?).
+
+This results in:
+
+- confusing UX ("did it save?")
+- reduced trust in the system
+- runtime coupling between Whitehall and Publishing API for editorial workflows
+- friction and delays in local development
+
+### Technical problem
+
+Taxon tagging for Whitehall-managed content is currently treated as externally-owned state:
+
+- Whitehall must query Publishing API at runtime to display tagging.
+- Draft and live semantics are harder to reason about.
+- Topic and world taxonomies must both be considered when reading/writing.
+- Data flow differs from other Whitehall associations.
+
+## Context
+
+- Taxonomies (topic + world) are maintained outside Whitehall (in Content Tagger).
+- Taxons are stored in Publishing API as content items.
+- Publishing API stores links by `content_id`.
+TODO: double-check the following definitions:
+- Link sets are document-scoped (not edition-scoped).
+- Edition links are draft-scoped and allow draft/live divergence.
+
+Whitehall prefers draftable associations (e.g. organisations via edition_links) so that changes made on a draft edition do not affect the live edition until publish.
+
+This RFC aligns taxon tagging with that model.
+
+## Investigation: Publishing API behaviour
+
+### Key findings
+
+TODO: double-check and verify the below.
+
+1. Taxons are not special in Publishing API.
+   - They are just another link type: `"taxons"`.
+   - There are no hardcoded business rules restricting which publishing app may set taxons.
+
+2. Publishing API does not distinguish topic vs world taxonomy at storage level.
+   - Both are stored under `"taxons"`.
+
+3. Link sets are tied to `content_id` and are not edition-scoped.
+   - Writing to link sets affects the document-level associations.
+
+4. Edition links are draft-scoped and allow draft/live divergence.
+
+5. Publishing API does not automatically merge partial link updates.
+   - PATCHing links requires sending the full desired set.
+   - Omitting links risks overwriting them.
+
+6. Content Tagger writes taxons by mutating Publishing API link sets.
+   - There is no enforcement that only Content Tagger may do so.
+
+Conclusion:
+
+There are no hidden business rules in Publishing API that prevent Whitehall from becoming authoritative for taxon tagging.
+
+The main risk is partial overwriting of link sets, which can be mitigated by always sending the full combined set.
+
+## Proposal
+
+### 1. Persist taxons locally (edition-scoped)
+
+Whitehall will store selected taxons per Edition.
+
+This enables draft editions to differ from live editions.
+
+Proposed model will be something like:
+
+- `edition_taxon_links`
+  - `edition_id`
+  - `taxon_content_id`
+  - `taxonomy_kind` (enum: `topic`, `world`)
+
+When a new edition is created, it will inherit taxons from the previous edition.
+
+### 2. Render from local persistence
+
+Whitehall UI will render taxon tagging from `edition_taxon_links`.
+
+Whitehall will no longer call Publishing API at runtime to determine which taxons an Edition is tagged to.
+
+This removes:
+
+- eventual-consistency issues
+- runtime dependency on Publishing API
+- cross-app state ambiguity
+
+### 3. Draft vs Live semantics
+
+Whitehall prefers draftable associations.
+
+Therefore:
+
+#### On save draft
+
+- Taxons are written as edition_links only.
+- Link sets are NOT updated.
+- Live associations remain unchanged.
+
+TODO: is there a case for dropping link set links altogether?
+
+#### On publish / republish
+
+- Taxons are written as edition_links.
+- The document’s link set is updated via `PATCH /v2/links/:content_id`.
+- The full combined set of topic + world taxons is sent.
+
+This ensures:
+
+- Draft changes do not affect live content prematurely.
+- Link sets remain authoritative for live content.
+- Downstream consumers receive correct associations.
+
+### 4. Always send full combined taxon set
+
+When updating link sets:
+
+- Whitehall must always send the complete combined set of topic + world taxons.
+- Partial updates are not permitted.
+
+This avoids accidental overwriting of one taxonomy with another.
+
+### 5. Continue fetching taxonomy catalogue
+
+Whitehall will continue to fetch and cache the list of available taxons from the publishing stack.
+
+This proposal changes tagging ownership, not taxonomy ownership.
+
+## Migration Plan
+
+### 1. Backfill
+
+For each Whitehall document:
+
+- Fetch existing taxon link sets from Publishing API.
+- Populate `edition_taxon_links` for the latest edition.
+
+Both topic and world taxons must be included.
+
+### 2. Dual-read period (temporary)
+
+For a limited period:
+
+- Compare local taxon set vs Publishing API link set.
+- Log diffs.
+- Identify edge cases.
+
+### 3. Switch UI reads
+
+Switch Whitehall to render from local persistence only.
+
+### 4. Switch publish writes
+
+Update publish/republish flow to:
+
+- Write edition_links
+- PATCH link set with full combined taxon set
+
+### 5. Remove runtime dependency
+
+Remove all runtime reads of taxon tagging from Publishing API.
+
+## Governance Considerations
+
+After this change:
+
+- Whitehall is authoritative for taxon tagging on Whitehall-managed content.
+- If Content Tagger mutates taxons for Whitehall content, those changes will be overwritten on next republish.
+
+Optional mitigations:
+
+- Prevent Whitehall content from being edited in Content Tagger.
+- Add validation/logging if non-Whitehall apps update taxons for Whitehall-owned content.
+
+## Risks and Mitigations
+
+### Risk: Partial link overwrites
+
+Mitigation:
+- Always send full combined taxon set on link set update.
+
+### Risk: Draft save mutates live links
+
+Mitigation:
+- Do not update link sets on save draft.
+- Only update link sets on publish/republish.
+
+### Risk: Backfill misses world taxonomy
+
+Mitigation:
+- Explicitly backfill both topic and world taxons.
+- Validate counts before switching.
+
+### Risk: Unexpected downstream dependency on Content Tagger
+
+Investigation shows:
+- Downstream systems rely on link sets, not on Content Tagger as a writer.
+- There are no hidden business rules coupling taxons to Content Tagger.
+
+Mitigation:
+- Dual-read phase and monitoring.
+
+## Alternatives Considered
+
+### Continue pulling from Publishing API
+
+Pros:
+- Single source of truth
+Cons:
+- Runtime coupling
+- UX inconsistency
+- Harder to reason about draft/live
+- Requires careful topic/world handling on every read
+
+### Optimistic UI but keep Publishing API authoritative
+
+Pros:
+- Less invasive
+Cons:
+- Does not align with “Whitehall is authoritative”
+- Still runtime-coupled
+
+### Make Content Tagger canonical for Whitehall content
+
+Rejected:
+- Whitehall is primary editorial interface.
+- Cross-app editing causes ambiguity.
+
+## Impact
+
+- Immediate UX improvement for tagging.
+- Reduced runtime coupling.
+- Consistent association model across Whitehall.
+- Clear ownership model for taxon tagging.
+- Explicit handling of topic + world taxonomy together.
+- Paves the way for easily configuring whether topic/world taxonomies should be required on a per-content type basis (following Whitehall's new config-driven approach).
+
+## Success Criteria
+
+- Tagging changes appear immediately after save.
+- Draft tagging differs from live until publish.
+- Publishing API link sets reflect correct combined taxon set after publish.
+- Whitehall no longer depends on Publishing API for runtime taxon lookup.


### PR DESCRIPTION
This RFC has been **closed** as **not accepted** - see [summary](https://github.com/alphagov/govuk-rfcs/pull/188#issuecomment-4021963250). ⛔ 

---

[Rendered view](https://github.com/alphagov/govuk-rfcs/blob/whitehall-taxons-refactor/rfc-188-make-whitehall-the-authority-on-its-taxons.md) 💅 

## Summary

This RFC proposes that Whitehall should be the canonical data store for which pieces of content are tagged to which topic and world taxonomies. It will be responsible for pushing the taxons to Publishing API, in the same way that it is already responsible for pushing other kinds of links, such as organisations and ministers.

Benefits:

- Enables different topic/world taxonomies on draft vs live content.
- Eradicates the root cause of a race condition whereby chosen taxonomies can take a while to 'stick' in Publishing API.
- Simplifies Whitehall and makes it more internally consistent.
- Removes runtime coupling between Whitehall and Publishing API for tagging.

### Recent context

1. We're currently working on a rewrite of Topical Events. It was mooted by the Content stakeholders that that format should not have the option of tagging to a topic taxonomy. Our other kinds of associations can be easily configured to be enabled or disabled via the StandardEdition 'config driven' architecture, but because taxons are implemented so differently, it's not clear that we'd be able to extend the same approach there.

2. Having an early look at multi-page architecture in Whitehall's new config-driven approach, we're likely to want to disable topic taxonomy choice from 'child documents' which should otherwise inherit from their parents. As per 1, the most idiomatic way to implement this would be to make taxonomy tagging a configurable property in the content type schema, which would be made easier if taxons worked in the same way as other associations.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3066